### PR TITLE
Require --expression, --function, or --executable

### DIFF
--- a/massedit.py
+++ b/massedit.py
@@ -359,7 +359,6 @@ def parse_command_line(argv):
                         help="shell-like file name patterns to process.")
     arguments = parser.parse_args(argv[1:])
 
-
     if not (arguments.expressions or
             arguments.functions or
             arguments.executables):


### PR DESCRIPTION
Sometimes, I accidentally run

```
$ massedit 'line.replace("foo", "bar")' '*.py'
```

and wonder why nothing happens. This resolves that.
