### PR TITLE
Ability to pass newline character for output files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,7 @@ expressions).
     -g FILE, --generate FILE
                           generate input file suitable for -f option
     --encoding ENCODING   Encoding of input and output files
+    --newline NEWLINE     Newline charachter for output files
 
   Examples:
   # Simple string substitution (-e). Will show a diff. No changes applied.
@@ -275,4 +276,3 @@ tgoodlet, https://github/tgoodlet
 .. _MIT License: http://en.wikipedia.org/wiki/MIT_License
 .. _autopep8: http://pypi.python.org/pypi/autopep8
 .. _Ned Batchelder's article: http://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html
-

--- a/massedit.py
+++ b/massedit.py
@@ -111,7 +111,7 @@ class MassEdit(object):
         self._executables = []
         self.dry_run = None
         self.encoding = 'utf-8'
-        self.newline = '\n'
+        self.newline = None
         if 'module' in kwds:
             self.import_module(kwds['module'])
         if 'code' in kwds:

--- a/massedit.py
+++ b/massedit.py
@@ -111,6 +111,7 @@ class MassEdit(object):
         self._executables = []
         self.dry_run = None
         self.encoding = 'utf-8'
+        self.newline = '\n'
         if 'module' in kwds:
             self.import_module(kwds['module'])
         if 'code' in kwds:
@@ -123,6 +124,8 @@ class MassEdit(object):
             self.dry_run = kwds['dry_run']
         if 'encoding' in kwds:
             self.encoding = kwds['encoding']
+        if 'newline' in kwds:
+            self.newline = kwds['newline']
 
     @staticmethod
     def import_module(module):  # pylint: disable=R0201
@@ -236,7 +239,7 @@ class MassEdit(object):
                     raise FileExistsError(msg)
             try:
                 os.rename(file_name, bak_file_name)
-                with io.open(file_name, 'w', encoding=self.encoding) as new:
+                with io.open(file_name, 'w', encoding=self.encoding, newline=self.newline) as new:
                     new.writelines(to_lines)
                 # Keeps mode of original file.
                 shutil.copymode(bak_file_name, file_name)
@@ -380,6 +383,8 @@ def parse_command_line(argv):
                         help="generate input file suitable for -f option")
     parser.add_argument("--encoding", dest="encoding",
                         help="Encoding of input and output files")
+    parser.add_argument("--newline", dest="newline",
+                        help="Newline charachter for output files")
     parser.add_argument("patterns", metavar="pattern",
                         nargs="*",  # argparse.REMAINDER,
                         help="shell-like file name patterns to process.")
@@ -464,7 +469,7 @@ def generate_fixer_file(output):
 def edit_files(patterns, expressions=None,
                functions=None, executables=None,
                start_dirs=None, max_depth=1, dry_run=True,
-               output=sys.stdout, encoding=None):
+               output=sys.stdout, encoding=None, newline=None):
     """Process patterns with MassEdit.
 
     Arguments:
@@ -492,7 +497,7 @@ def edit_files(patterns, expressions=None,
     if executables and not is_list(executables):
         raise TypeError("executables should be a list of program names")
 
-    editor = MassEdit(dry_run=dry_run, encoding=encoding)
+    editor = MassEdit(dry_run=dry_run, encoding=encoding, newline=newline)
     if expressions:
         editor.set_code_exprs(expressions)
     if functions:
@@ -543,7 +548,8 @@ def command_line(argv):
                        max_depth=arguments.max_depth,
                        dry_run=arguments.dry_run,
                        output=arguments.output,
-                       encoding=arguments.encoding)
+                       encoding=arguments.encoding,
+                       newline=arguments.newline)
     # If the output is not sys.stdout, we need to close it because
     # argparse.FileType does not do it for us.
     is_sys = arguments.output in [sys.stdout, sys.stderr]

--- a/tests.py
+++ b/tests.py
@@ -326,10 +326,9 @@ class TestMassEditWithFile(unittest.TestCase):
         diffs = self.editor.edit_file(self.file_name)
         self.assertEqual(diffs, [])
 
-    def test_eol_setting(self):
+    def test_forcing_end_of_line_for_output_files(self):
         """Check files with CRLF are created with LF when using newline setting"""
-        newline = '\n'
-        self.editor.newline = newline
+        self.editor.newline = '\n'
 
         content = "This is a line finishing with CRLF\r\n"
 
@@ -345,7 +344,16 @@ class TestMassEditWithFile(unittest.TestCase):
 
         self.assertEqual(diffs, [])
 
-        # TODO: Check EOL of self.file_name before and after
+        with io.open(self.file_name) as f:
+            f.readline()
+            output_newline = f.newlines
+
+        expected_eol = self.editor.newline
+        if expected_eol is None:
+            # If not specified use the string to terminate lines on the current platform
+            expected_eol = os.linesep
+
+        self.assertEqual(expected_eol, output_newline)
 
 class TestMassEditWithZenFile(TestMassEditWithFile):  # pylint: disable=R0904
 

--- a/tests.py
+++ b/tests.py
@@ -326,6 +326,26 @@ class TestMassEditWithFile(unittest.TestCase):
         diffs = self.editor.edit_file(self.file_name)
         self.assertEqual(diffs, [])
 
+    def test_eol_setting(self):
+        """Check files with CRLF are created with LF when using newline setting"""
+        newline = '\n'
+        self.editor.newline = newline
+
+        content = "This is a line finishing with CRLF\r\n"
+
+        self.write_input_file(content)
+
+        def identity(lines, _):
+            """Return the line itself."""
+            for line in lines:
+                yield line
+
+        self.editor.append_function(identity)
+        diffs = self.editor.edit_file(self.file_name)
+
+        self.assertEqual(diffs, [])
+
+        # TODO: Check EOL of self.file_name before and after
 
 class TestMassEditWithZenFile(TestMassEditWithFile):  # pylint: disable=R0904
 


### PR DESCRIPTION
I've run into a situation where I need to make sure the output files are written with a specific EOL. In this particular case I need to read files with `CRLF` EOLs and write them in `LF` regardless of OS. 

Ideally I think the EOL from the source files should be respected but I don't think that's a simple problem to solve at point so adding a new flag to specify the OEL for the output files feels like a good compromise.

I'm unsure if this is needed but many people or if this is the best way of going about it but I'm happy to make changes as required.